### PR TITLE
Allow client to specify endpoint

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Expected Behavior
+
+## Current Behavior
+
+## Steps to Reproduce
+
+1.
+1.
+1.
+1.
+
+## Context (Environment)
+
+## Detailed Description

--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ The API node(s) act as a [DMZ](https://searchsecurity.techtarget.com/definition/
 
 #### `POST` new transaction
 
+**Method 1**: A helper package found in `client.go` is created to simplify this process. To `POST` a new transaction to a Herdius Blockchain API node, simply run `go run client.go [API endpoint]` in which the `[API endpoint]` is the IP or DNS address of the API node of the chain to send the transaction to. The default address is `localhost`, meaning that you have an API node listening on your host server/computer.
+
+Example:
+
+```
+// Send transaction to primary Herdius test chain (with API node IP address at `3.209.249.184`)
+go run client.go 3.209.249.184
+
+// Send transaction to host's API node
+go run client.go
+go run client.go localhost // equivalent to ^
+```
+
+**Method 2**: Manually `POST` to API node
+
+TODO
+
 #### `GET` account details
 
 #### `GET` transaction details

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Intent
+
+The Herdius Blockchain API provides an API interface in which end users can interract with both the core [Herdius Blockchain](https://herdius.com), as well as it's various test chains. At the moment, a fully functional chain is still on its way to deployment, thus only test chains are available for API interraction.
+
+The API node(s) act as a [DMZ](https://searchsecurity.techtarget.com/definition/DMZ) for the secured Herdius Cluster (consisting of the Supervisor and Validator nodes) which, in the case of deployed test chains, operate in a fully private subnet. Thus, DDoS and similar malicious attacks will disrupt service at the API level, but the chains themselves will still function in a completely undisrupted way.
+
+## Usage
+
+#### `POST` new transaction
+
+#### `GET` account details
+
+#### `GET` transaction details
+
+#### `GET` block details

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 
 	b64 "encoding/base64"
 	"encoding/json"
@@ -79,7 +80,16 @@ func main() {
 		log.Fatalf("Failed to Marshal %v", err)
 	}
 
-	response, err := http.Post("http://localhost:80/tx", "application/json", bytes.NewBuffer(txJSON))
+	var endpoint string
+	if len(os.Args) > 1 {
+		endpoint = os.Args[1]
+	} else {
+		endpoint = "localhost"
+	}
+	endpoint = "http://" + endpoint + ":80/tx"
+	log.Println("endpoint:", endpoint)
+
+	response, err := http.Post(endpoint, "application/json", bytes.NewBuffer(txJSON))
 	if err != nil {
 		log.Fatalf("Failed to Marshal %v", err)
 	}


### PR DESCRIPTION
## Problem

With our test chains currently deployed, we need our API and supported API actions to allow for different endpoints, as opposed to hardcoding `localhost`.
The `client` package is one such file that needs to allow for pointing to different API and chain endpoints.

## Solution

Allow for `go run client.go` package to specify endpoint parameters.

## Testing Done and Results

```
 ❯ go run client.go 3.209.249.184
2019/04/05 11:14:40 endpoint: http://3.209.249.184:80/tx
2019/04/05 11:14:41
2019/04/05 11:14:41
```

## Follow-up Work Needed

Further document in `README`