### PR TITLE
allow for multiple environments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 	"sync"
@@ -13,14 +14,14 @@ type detail struct {
 	SupervisorPort int
 	TCP            string
 	ConnectionPort int
+	SelfIP         string
 }
 
 var configuration *detail
 var once sync.Once
 
 // GetConfiguration ...
-func GetConfiguration() *detail {
-
+func GetConfiguration(env string) *detail {
 	once.Do(func() {
 		viper.SetConfigName("config")   // Config file name without extension
 		viper.AddConfigPath("./config") // Path to config file
@@ -29,13 +30,13 @@ func GetConfiguration() *detail {
 			log.Printf("Config file not found: %v", err)
 		} else {
 			configuration = &detail{
-				SupervisorHost: viper.GetString("dev.supervisorhost"),
-				SupervisorPort: viper.GetInt("dev.supervisorport"),
-				TCP:            viper.GetString("dev.tcp"),
-				ConnectionPort: viper.GetInt("dev.connectionport"),
+				SupervisorHost: viper.GetString(fmt.Sprint(env, ".supervisorhost")),
+				SupervisorPort: viper.GetInt(fmt.Sprint(env, ".supervisorport")),
+				TCP:            viper.GetString(fmt.Sprint(env, ".tcp")),
+				ConnectionPort: viper.GetInt(fmt.Sprint(env, ".connectionport")),
+				SelfIP:         viper.GetString(fmt.Sprint(env, ".selfip")),
 			}
 		}
-
 	})
 
 	return configuration

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,9 @@ var once sync.Once
 
 // GetConfiguration ...
 func GetConfiguration(env string) *detail {
+	if env != "staging" {
+		env = "dev"
+	}
 	once.Do(func() {
 		viper.SetConfigName("config")   // Config file name without extension
 		viper.AddConfigPath("./config") // Path to config file

--- a/config/config.toml
+++ b/config/config.toml
@@ -3,3 +3,11 @@ supervisorhost      = "127.0.0.1"
 supervisorport      = 3000
 tcp                 = "tcp"
 connectionport      = 5555
+selfip              = "localhost"
+
+[staging]
+supervisorhost      = "10.0.1.159"
+supervisorport      = 3000
+tcp                 = "tcp"
+connectionport      = 5555
+selfip              = "10.0.0.34"

--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -2,6 +2,7 @@
 set -ex
 
 source /etc/bashrc
+export ENV=staging
 cd /root/go/src/github.com/herdius/herdius-blockchain-api
 go get ./...
 go run /root/go/src/github.com/herdius/herdius-blockchain-api/server/server.go > /dev/null 2> /dev/null < /dev/null &

--- a/handler/account.go
+++ b/handler/account.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/herdius/herdius-blockchain-api/config"
@@ -29,7 +30,11 @@ type Account struct {
 // Account details for a given account address
 func (s *service) GetAccountByAddress(accAddr string) (*Account, error) {
 
-	net, err := apiNet.GetNetworkBuilder().Build()
+	env := os.Getenv("ENV")
+	if env == "" {
+		env = "dev"
+	}
+	net, err := apiNet.GetNetworkBuilder(env).Build()
 	if err != nil {
 		log.Error().Msgf("Failed to build network:%v", err)
 	}

--- a/handler/account.go
+++ b/handler/account.go
@@ -42,7 +42,7 @@ func (s *service) GetAccountByAddress(accAddr string) (*Account, error) {
 	go net.Listen()
 	defer net.Close()
 
-	configuration := config.GetConfiguration()
+	configuration := config.GetConfiguration(env)
 	supervisorAddress := configuration.GetSupervisorAddress()
 
 	ctx := network.WithSignMessage(context.Background(), true)

--- a/handler/block.go
+++ b/handler/block.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -38,7 +39,11 @@ var (
 )
 
 func (s *service) GetBlockByHeight(height uint64) (*protobuf.BlockResponse, error) {
-	net, err := apiNet.GetNetworkBuilder().Build()
+	env := os.Getenv("ENV")
+	if env == "" {
+		env = "dev"
+	}
+	net, err := apiNet.GetNetworkBuilder(env).Build()
 	if err != nil {
 		return nil, fmt.Errorf(fmt.Sprintf("Failed to build network:%v", err))
 	}
@@ -46,7 +51,7 @@ func (s *service) GetBlockByHeight(height uint64) (*protobuf.BlockResponse, erro
 	go net.Listen()
 	defer net.Close()
 
-	configuration := config.GetConfiguration()
+	configuration := config.GetConfiguration(env)
 
 	supervisorAddress := configuration.GetSupervisorAddress()
 

--- a/handler/tx.go
+++ b/handler/tx.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"encoding/json"
@@ -18,7 +19,12 @@ import (
 )
 
 func (s *service) SendTxToBlockchain(txReq protobuf.TxRequest) (*protobuf.TxResponse, error) {
-	net, err := apiNet.GetNetworkBuilder().Build()
+
+	env := os.Getenv("ENV")
+	if env == "" {
+		env = "dev"
+	}
+	net, err := apiNet.GetNetworkBuilder(env).Build()
 	if err != nil {
 		log.Print(err)
 	}
@@ -26,7 +32,7 @@ func (s *service) SendTxToBlockchain(txReq protobuf.TxRequest) (*protobuf.TxResp
 	go net.Listen()
 	defer net.Close()
 
-	configuration := config.GetConfiguration()
+	configuration := config.GetConfiguration(env)
 
 	supervisorAddress := configuration.GetSupervisorAddress()
 

--- a/network/service.go
+++ b/network/service.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"os/user"
 	"strconv"
 	"sync"
@@ -33,10 +34,10 @@ func networkBuilder(env string) *network.Builder {
 	}
 
 	configuration := config.GetConfiguration(env)
-	port := configuration.ConnectionPort
-	host := configuration.SelfIP
+	fmt.Println("SelfIP:", configuration.SelfIP)
+	fmt.Println("SupervisorIP:", configuration.SupervisorHost)
 
-	nodeAddress := host + ":" + strconv.Itoa(port)
+	nodeAddress := configuration.SelfIP + ":" + strconv.Itoa(configuration.ConnectionPort)
 
 	nodekey, err := keystore.LoadOrGenNodeKey(user.HomeDir + "/" + nodeAddress + "_peer_id.json")
 
@@ -64,7 +65,7 @@ func networkBuilder(env string) *network.Builder {
 
 	builder := network.NewBuilder()
 	builder.SetKeys(keys)
-	builder.SetAddress(network.FormatAddress(configuration.TCP, host, uint16(port)))
+	builder.SetAddress(network.FormatAddress(configuration.TCP, configuration.SelfIP, uint16(configuration.ConnectionPort)))
 
 	return builder
 

--- a/network/service.go
+++ b/network/service.go
@@ -19,22 +19,22 @@ var builder *network.Builder
 var once sync.Once
 
 // GetNetworkBuilder will instantiate network builder only once
-func GetNetworkBuilder() *network.Builder {
+func GetNetworkBuilder(env string) *network.Builder {
 	once.Do(func() {
-		builder = networkBuilder()
+		builder = networkBuilder(env)
 	})
 	return builder
 }
 
-func networkBuilder() *network.Builder {
+func networkBuilder(env string) *network.Builder {
 	user, err := user.Current()
 	if err != nil {
 		panic(err)
 	}
 
-	configuration := config.GetConfiguration()
+	configuration := config.GetConfiguration(env)
 	port := configuration.ConnectionPort
-	host := "localhost"
+	host := configuration.SelfIP
 
 	nodeAddress := host + ":" + strconv.Itoa(port)
 


### PR DESCRIPTION
## Problem

The API server is currently hardcoded to expect that the Supervisor is running on `localhost` and complimentarily that the IP to broadcast to the network for P2P connections is `127.0.0.1`. This is very problematic for any situation where nodes need to be distributed (all non-dev envs).

## Solution

Allow for environment setting through use of an `ENV` host environment variable.

To use the STAGING environment in the `config/config.toml`:
```
export ENV=staging
```
To use the DEV environment in the `config/config.toml`, use any other value or unset the environment variable completely.

## Testing Done and Results

![image](https://user-images.githubusercontent.com/6162362/55968443-48e24800-5c7c-11e9-8d31-e19fe8a7dfc5.png)


## Follow-up Work Needed

Test in staging area.
* Do we now have a consistently connected API=>Supervisor=>API request-response cycle, via CICD pipeline? Can't test this until merged.