### PR TITLE
Builder requires environment input

### DIFF
--- a/network/service.go
+++ b/network/service.go
@@ -63,7 +63,7 @@ func networkBuilder(env string) *network.Builder {
 	opcode.RegisterMessageType(opcode.Opcode(1117), &apiProtobuf.TxRequest{})
 	opcode.RegisterMessageType(opcode.Opcode(1118), &apiProtobuf.TxResponse{})
 
-	builder := network.NewBuilder()
+	builder := network.NewBuilder(env)
 	builder.SetKeys(keys)
 	builder.SetAddress(network.FormatAddress(configuration.TCP, configuration.SelfIP, uint16(configuration.ConnectionPort)))
 


### PR DESCRIPTION
## Problem

The network dependencies in core have updated, but they haven't updated on the api server 

## Solution

Update to provide the API server with the environment for network building