### PR TITLE
Make config an absolute path instead of relative

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"sync"
 
@@ -27,8 +28,9 @@ func GetConfiguration(env string) *detail {
 	}
 	log.Println("environment sourced from config:", env)
 	once.Do(func() {
-		viper.SetConfigName("config")    // Config file name without extension
-		viper.AddConfigPath("../config") // Path to config file
+		dirname := os.Getenv("GOPATH")
+		viper.SetConfigName("config")                                                          // Config file name without extension
+		viper.AddConfigPath(dirname + "/src/github.com/herdius/herdius-blockchain-api/config") // Path to config file
 		err := viper.ReadInConfig()
 		if err != nil {
 			log.Printf("Config file not found: %v", err)


### PR DESCRIPTION
## Problem

We broke our `master` branch with this change:
https://github.com/herdius/herdius-blockchain-api/pull/32/files#diff-3baf47c64847a8fb8aaa8cc2e088513bR31

## Solution

Unbreak that change by making the config path, absolute.

## Testing Done and Results

```
❯ go run server/server.go -env=dev
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Timestamp
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.ID
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.ChildBlock
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Message
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Ping
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Pong
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.LookupNodeRequest
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.LookupNodeResponse
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Bytes
2019/04/23 09:22:39 proto: duplicate proto type registered: protobuf.Timestamp
2019/04/23 09:22:39 Opening API
2019/04/23 09:22:39 environment sourced from config: dev
SelfIP: localhost
SupervisorIP: 127.0.0.1
2019/04/23 09:22:39 current dir: /Users/ColeBittel/.go
2019/04/23 09:22:39 environment sourced from config: dev
9:22AM INF Listening for peers. address=tcp://127.0.0.1:5555
2019/04/23 09:22:39 No peers discovered in network

```
