### PR TITLE
client.go send multiple txs; logging to file not stdout

### DIFF
--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -5,6 +5,7 @@ source /etc/bashrc
 export ENV=staging
 export GOPATH=/root/go
 cd /root/go/src/github.com/herdius/herdius-blockchain-api
+mkdir -p /var/log/herdius/herdius-blockchain-api/log/
 go get ./...
-go run /root/go/src/github.com/herdius/herdius-blockchain-api/server/server.go -env=staging > /dev/null 2> /dev/null < /dev/null &
+go run /root/go/src/github.com/herdius/herdius-blockchain-api/server/server.go -env=staging > /var/log/herdius/herdius-blockchain-api/log/server.log 2> /var/log/herdius/herdius-blockchain-api/log/server.log < /dev/null &
 echo "server started in background"


### PR DESCRIPTION
## Problem

1. Logging on remote machines is useless, as the current logging mechanism is to `/dev/null` for both stdout and stderr. Logging is important for us to be able to view for debugging issues.
2. The `client.go` file only POSTs a single transaction, making bulk transaction sending tedious.

## Solution

1. Log all server output to a file in `/var/log/herdius/herdius-blockchain-api/log/server.log` including both stdout and stderr. Delete this file upon new server start, so as to not fill disk space on API node.
2. Post 30 new tx's with different nonce values for the `client.go` file.

## Testing Done and Results

```
[root@ip-10-0-0-34 herdius-blockchain-api]# cat /var/log/herdius/herdius-blockchain-api/log/server.log | wc -l
19
[root@ip-10-0-0-34 herdius-blockchain-api]# cat /var/log/herdius/herdius-blockchain-api/log/server.log | wc -l
20
```