### PR TITLE
added a method to send external transactions

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,14 +33,24 @@ func main() {
 
 	if strings.EqualFold(*txType, "update") {
 		sendAccountRegisterTx(endpoint)
+	} else if strings.EqualFold(*txType, "external") {
+		postExternalTx(endpoint)
 	} else {
 		postTx(endpoint)
 	}
 
 }
+
 func sendAccountRegisterTx(endpoint string) {
 	// Create key pairs and store in a local file
+	// User 1
+	// Address: HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm
 	senderPrivKey, err := key.LoadOrGenNodeKey("./tempKey.json")
+
+	// User 2
+	// Address: HKTXmdsHyZn1B2ErRKiG4iN34YixCgdQgx
+	//senderPrivKey, err := key.LoadOrGenNodeKey("./tempKeySign.json")
+
 	if err != nil {
 		panic(err)
 	}
@@ -65,12 +75,12 @@ func sendAccountRegisterTx(endpoint string) {
 	// In case ETH or external asset address is required to be registered
 	// use the below Asset Object
 	/* asset = &protobuf.Asset{
-		Category: "crypto",
-		Symbol:   "HER",
-		Network:  "Herdius",
-		Value:    15,
-		Fee:      0,
-		Nonce:    0,
+		Category:              "crypto",
+		Symbol:                "ETH",
+		Network:               "Herdius",
+		Value:                 15,
+		Fee:                   0,
+		Nonce:                 1,
 		ExternalSenderAddress: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
 	} */
 	tx := protobuf.Tx{
@@ -96,6 +106,86 @@ func sendAccountRegisterTx(endpoint string) {
 	if err != nil {
 		log.Fatalf("Failed to Marshal %v", err)
 	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewBuffer(txJSON))
+	if err != nil {
+		log.Fatalf("Failed to Marshal %v", err)
+	}
+
+	defer response.Body.Close()
+	body, readErr := ioutil.ReadAll(response.Body)
+	if readErr != nil {
+		log.Fatalf("Failed to read http response %s.", readErr)
+	}
+	var txResponse protobuf.TxResponse
+	jsonErr := json.Unmarshal(body, &txResponse)
+	if jsonErr != nil {
+		log.Fatalf("Failed to Unmarshal %s.", jsonErr)
+	}
+
+	log.Println(txResponse.TxId)
+	log.Println(txResponse.Status)
+}
+
+func postExternalTx(endpoint string) {
+	// Create key pairs and store in a local file
+	// User 1
+	// Address: HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm
+	senderPrivKey, err := key.LoadOrGenNodeKey("./tempKey.json")
+	if err != nil {
+		panic(err)
+	}
+	// User 2
+	// Address: HKTXmdsHyZn1B2ErRKiG4iN34YixCgdQgx
+	rcvrPrivKey, err := key.LoadOrGenNodeKey("./tempKeySign.json")
+
+	sendPubKey := senderPrivKey.PubKey()
+	var pubkeyBytes secp256k1.PubKeySecp256k1
+	pubkeyBytes = sendPubKey.(secp256k1.PubKeySecp256k1)
+
+	senderB64 := b64.StdEncoding.EncodeToString(pubkeyBytes[:])
+
+	senderAddress := sendPubKey.GetAddress()
+
+	recPubKey := rcvrPrivKey.PubKey()
+	recAddress := recPubKey.GetAddress()
+	log.Println("Sender Address: " + senderAddress)
+	log.Println("Receiver Address: " + recAddress)
+
+	msg := "Send ETH Tokens"
+	asset := &protobuf.Asset{
+		Category: "crypto",
+		Symbol:   "ETH",
+		Network:  "Herdius",
+		Value:    1,
+		Fee:      1,
+		Nonce:    uint64(7),
+	}
+
+	//sig = b64.StdEncoding.EncodeToString(sig)
+	tx := protobuf.Tx{
+		SenderAddress:   senderAddress,
+		SenderPubkey:    senderB64,
+		RecieverAddress: recAddress,
+		Asset:           asset,
+		Message:         msg,
+	}
+
+	// Sign the transaction detail
+	txbBeforeSign, _ := json.Marshal(tx)
+
+	sig, err := senderPrivKey.PrivKey.Sign(txbBeforeSign)
+
+	tx.Sign = b64.StdEncoding.EncodeToString(sig)
+
+	// Post tx to blockchain.
+	txReq := protobuf.TxRequest{
+		Tx: &tx,
+	}
+	txJSON, err := json.Marshal(txReq)
+	if err != nil {
+		log.Fatalf("Failed to Marshal %v", err)
+	}
+
 	response, err := http.Post(endpoint, "application/json", bytes.NewBuffer(txJSON))
 	if err != nil {
 		log.Fatalf("Failed to Marshal %v", err)


### PR DESCRIPTION
## Problem
Value transfer implementation logic is modified in [herdius-core](https://github.com/herdius/herdius-core/pull/43)  for external assets according to JSON object representation of account state in herdius blockchain. So need a go client to send external transactions.

Asana Link:
[Problem description in Asana](https://app.asana.com/0/998359196895599/1123326413582231)
Asana Link: 

## Solution
Created a method that sends external transactions.
To run it execute the below command.

`go run client.go -txtype=external`


## Testing Done and Results

## Follow-up Work Needed
