### PR TITLE
Block response in JSON format

### DIFF
--- a/handler/block.go
+++ b/handler/block.go
@@ -17,11 +17,11 @@ import (
 
 // Block will hold block detail retrieved from blockchain
 type Block struct {
-	BlockHeight       uint64
-	Timestamp         int64 // Timestamp of block intialization
-	Transactions      uint64
-	SupervisorAddress string // Herdius Address of Supervisor node
-	StateRoot         []byte
+	BlockHeight       uint64 `json:"blockHeight"`
+	Timestamp         int64  `json:"timestamp"` // Timestamp of block intialization
+	Transactions      uint64 `json:"transactionsCount"`
+	SupervisorAddress string `json:"supervisorIP"` // Herdius Address of Supervisor node
+	StateRoot         []byte `json:"stateRoot"`
 }
 
 // BlockI is an interface to provide block specific services
@@ -75,8 +75,10 @@ func GetBlockByHeight(w http.ResponseWriter, r *http.Request, net *network.Netwo
 	if err != nil {
 		fmt.Fprint(w, err)
 	}
+
 	if block.Time != nil {
-		b := Block{
+
+		block := Block{
 			BlockHeight:       block.BlockHeight,
 			Timestamp:         block.Time.Seconds,
 			Transactions:      block.Transactions,
@@ -84,7 +86,7 @@ func GetBlockByHeight(w http.ResponseWriter, r *http.Request, net *network.Netwo
 			StateRoot:         block.StateRoot,
 		}
 		log.Info().Msgf("Processed for Block Height: %d", block.BlockHeight)
-		fmt.Fprint(w, b)
+		json.NewEncoder(w).Encode(block)
 
 	} else {
 		fmt.Fprint(w, "Block not found for block height: "+heightJSON)


### PR DESCRIPTION
## Problem
Right now when block detail is enquired through a rest endpoints, it gives a reply without the field names. 

A proper JSON response has to be returned when block details are provided to end users.
Asana Link: 
https://app.asana.com/0/998359196895599/1120852002402144
## Solution
Provided a way to get the block details respond in JSON format
## Testing Done and Results
{
  "blockHeight": 4,
  "timestamp": 1558516185,
  "transactionsCount": 1,
  "supervisorIP": "tcp://127.0.0.1:5555",
  "stateRoot": "ERz/nB2F60jSRPzcSED8/yCrs7YSe9aH8Fd7VPm15hY="
}
## Follow-up Work Needed
