### PR TITLE
config: fix wrong viper get type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,11 +48,11 @@ func GetConfiguration(env string) *detail {
 				ConnectionPort: viper.GetInt(fmt.Sprint(env, ".connectionport")),
 				SelfIP:         viper.GetString(fmt.Sprint(env, ".selfip")),
 				DBHost:         viper.GetString(fmt.Sprint(env, ".dbhost")),
-				DBPort:         viper.GetString(fmt.Sprint(env, ".dbport")),
+				DBPort:         viper.GetInt(fmt.Sprint(env, ".dbport")),
 				DBName:         viper.GetString(fmt.Sprint(env, ".dbname")),
 				DBUser:         viper.GetString(fmt.Sprint(env, ".dbuser")),
 				DBPass:         viper.GetString(fmt.Sprint(env, ".dbpass")),
-				DBSslMode:      viper.GetString(fmt.Sprint(env, ".dbsslmode")),
+				DBSslMode:      viper.GetBool(fmt.Sprint(env, ".dbsslmode")),
 			}
 		}
 	})


### PR DESCRIPTION
## Problem

Wrong usage of viper.Get* for db port and ssl mode.

## Solution

Use right methods.

## Testing Done and Results

## Follow-up Work Needed
