### PR TITLE
update perms and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The API node(s) act as a [DMZ](https://searchsecurity.techtarget.com/definition/
 
 ## Setup
 
+#### Postgresql 
+
 You need a running instance of Postgresql. Set theses environment variables (or set them in your config file):
 
  - env_DBHOST
@@ -16,6 +18,12 @@ You need a running instance of Postgresql. Set theses environment variables (or 
  - env-DBSSLMODE
 
 Where env is corresponding to current environment.
+
+#### Supervisor
+
+Dependencies:
+
+* `jq`
 
 ## Usage
 

--- a/appspec.yml
+++ b/appspec.yml
@@ -4,6 +4,10 @@ files:
   - source: /
     destination: /root/go/src/github.com/herdius/herdius-blockchain-api
     overwrite: true
+permissions:
+  - object: /root/go/src/github.com/herdius/herdius-blockchain-api/deployment
+    pattern: "**"
+    mode: 755
 hooks:
   BeforeInstall:
     - location: deployment/kill_old_server.sh

--- a/client.go
+++ b/client.go
@@ -237,15 +237,16 @@ func postTx(endpoint string) {
 	if err != nil {
 		panic(err)
 	}
-	for i := 51; i <= 51; i++ {
+	for i := 1; i <= 1; i++ {
 
 		asset := &protobuf.Asset{
 			Category: "crypto",
 			Symbol:   "HER",
 			Network:  "Herdius",
-			Value:    100,
-			Fee:      1,
-			Nonce:    uint64(i),
+			//Value:    100,
+			Value: 0,
+			Fee:   1,
+			Nonce: uint64(i),
 		}
 
 		//sig = b64.StdEncoding.EncodeToString(sig)
@@ -255,6 +256,7 @@ func postTx(endpoint string) {
 			RecieverAddress: recAddress,
 			Asset:           asset,
 			Message:         msg,
+			//Type:            "update",
 		}
 
 		// Sign the transaction detail


### PR DESCRIPTION
## Problem

The API server attempts to launch destroy the old API, and launch the new API, via `start_server.sh`. However, it doesn't have adequate permissions to execute this file.

## Solution

Implement the same solution with the same solutions as is done in the [Supervisor repo](https://github.com/herdius/herdius-core/blob/master/appspec.yml#L7).

## Follow-up Work Needed

Watch it successfully execute in staging.