### PR TITLE
handler: fix getStore

### DIFF
--- a/handler/db.go
+++ b/handler/db.go
@@ -15,11 +15,12 @@ var (
 
 func getStore(dsn string) store.Storer {
 	once.Do(func() {
-		var err error
-		db, err = postgres.NewStore(dsn)
+		s, err := postgres.NewStore(dsn)
 		if err != nil {
 			log.Printf("Failed to init store: %v", err)
+			return
 		}
+		db = s
 	})
 	return db
 }


### PR DESCRIPTION
getStore intends to set db only if NewStore returns no error. But in
case of error, it returns a store.Storer also, causing db is set to
non-nil.

## Problem

Asana Link: 

## Solution

## Testing Done and Results

## Follow-up Work Needed
