### PR TITLE
store: fix wrong return tx

### DIFF
--- a/store/tx.go
+++ b/store/tx.go
@@ -70,5 +70,5 @@ func FromTxDetailResponse(txDetail *protobuf.TxDetailResponse) *Tx {
 	tx.Sign = txDetail.Tx.Sign
 	tx.BlockID = txDetail.BlockId
 
-	return nil
+	return tx
 }


### PR DESCRIPTION
## Problem

Convert from protobuf TX to store TX is returning nil.

## Solution

Should return tx, the `nil` is from the first skeleton code.

## Testing Done and Results

Passed.

## Follow-up Work Needed
