### PR TITLE
handle store posted tx in separate goroutine

### DIFF
--- a/handler/tx.go
+++ b/handler/tx.go
@@ -48,18 +48,10 @@ func (s *service) PostTx(txReq protobuf.TxRequest, net *network.Network, env str
 		log.Printf("Tx ID: %v", msg.TxId)
 		log.Printf("Tx status: %v", msg.Status)
 		if s := getStore(configuration.DBConnString()); s != nil && msg.TxId != "" {
-			txDetailReq := protobuf.TxDetailRequest{TxId: msg.TxId}
-			res, err := supervisorNode.Request(ctx, &txDetailReq)
-			if err != nil {
-				log.Printf("Failed to get Tx after creating")
-			} else {
-				if txDetail, ok := res.(*protobuf.TxDetailResponse); ok {
-					if err := s.Save(store.FromTxDetailResponse(txDetail)); err != nil {
-						log.Printf("Failed to save Tx to database: %v", err)
-					}
-					log.Printf("Tx saved to database")
-				}
+			if err := s.Save(&store.Tx{ID: msg.TxId, Status: store.StatusPending}); err != nil {
+				log.Printf("Failed to save Tx to database: %v", err)
 			}
+			log.Printf("Tx saved to database")
 		}
 		return msg, nil
 	}

--- a/store/postgres/postgres.go
+++ b/store/postgres/postgres.go
@@ -87,6 +87,27 @@ WHERE
 	sender_address = $1
 `
 
+const txSelectByStatusStmt = `
+SELECT
+	id,
+	sender_address,
+	sender_pubkey,
+	receiver_address,
+	category,
+	symbol,
+	network,
+	value,
+	nonce,
+	message,
+	sign,
+	status,
+	block_id,
+	created_date
+FROM "transaction"
+WHERE
+	status = $1
+`
+
 const txUpdateStmt = `
 UPDATE "transaction" SET
 	sender_address = :sender_address,
@@ -187,6 +208,15 @@ func (s *Store) GetBySender(address string) ([]*store.Tx, error) {
 func (s *Store) GetByAssetAndSender(asset, address string) ([]*store.Tx, error) {
 	var txs []*store.Tx
 	if err := s.db.Select(&txs, txSelectByAssetAndSenderStmt, asset, address); err != nil {
+		return nil, err
+	}
+	return txs, nil
+}
+
+// GetByStatus returns list of transaction filter by given status
+func (s *Store) GetByStatus(status string) ([]*store.Tx, error) {
+	var txs []*store.Tx
+	if err := s.db.Select(&txs, txSelectByStatusStmt, status); err != nil {
 		return nil, err
 	}
 	return txs, nil

--- a/store/store.go
+++ b/store/store.go
@@ -9,4 +9,5 @@ type Storer interface {
 	Get(id string) (*Tx, error)
 	GetBySender(address string) ([]*Tx, error)
 	GetByAssetAndSender(asset, address string) ([]*Tx, error)
+	GetByStatus(status string) ([]*Tx, error)
 }

--- a/store/sync.go
+++ b/store/sync.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"context"
+
+	"github.com/herdius/herdius-blockchain-api/config"
+	"github.com/herdius/herdius-blockchain-api/protobuf"
+	"github.com/herdius/herdius-core/p2p/network"
+)
+
+// SyncPendingTxs syncs pending status with core
+func SyncPendingTxs(s Storer, net *network.Network, env string) error {
+	configuration := config.GetConfiguration(env)
+	supervisorAddress := configuration.GetSupervisorAddress()
+	supervisorNode, _ := net.Client(supervisorAddress)
+	txs, err := s.GetByStatus(StatusPending)
+	if err != nil {
+		return err
+	}
+
+	for _, tx := range txs {
+		txDetailReq := protobuf.TxDetailRequest{TxId: tx.ID}
+		ctx := network.WithSignMessage(context.Background(), true)
+		res, err := supervisorNode.Request(ctx, &txDetailReq)
+		if err != nil {
+			return err
+		}
+		if msg, ok := res.(*protobuf.TxDetailResponse); ok {
+			if msg.Tx != nil {
+				if err := s.Update(FromTxDetailResponse(msg)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/store/tx.go
+++ b/store/tx.go
@@ -6,6 +6,9 @@ import (
 	"github.com/herdius/herdius-blockchain-api/protobuf"
 )
 
+// StatusPending indicates a TX is in pending state
+const StatusPending = "pending"
+
 // Tx ...
 type Tx struct {
 	ID              string    `db:"id"`


### PR DESCRIPTION
## Problem

Posted TX won't be available in core immediately, so saving it to local DB right after API call is not doable.

## Solution

Save posted TX as pending state in local database, spawn a separate goroutine to update these txs.

## Testing Done and Results

## Follow-up Work Needed
