### PR TITLE
server: fix lock tx url path overlapping

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -176,7 +176,7 @@ func addRoutes(net *coreNet.Network, env string, router *mux.Router) {
 		func(w http.ResponseWriter, r *http.Request) {
 			handler.GetTxsByAssetAndAddress(w, r, net, env)
 		}).Methods("GET")
-	router.HandleFunc("/txs/{block_number}/locked",
+	router.HandleFunc("/txs/lock/{block_number}",
 		func(w http.ResponseWriter, r *http.Request) {
 			handler.GetLockedTxsByBlockNumber(w, r, net, env)
 		}).Methods("GET")


### PR DESCRIPTION
## Problem

Get lock txs url path is overlapping with get txs by address.

## Solution

Change get lock txs url path.

## Testing Done and Results

## Follow-up Work Needed
