### PR TITLE
server: fix lock tx url path overlapping again

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -176,7 +176,7 @@ func addRoutes(net *coreNet.Network, env string, router *mux.Router) {
 		func(w http.ResponseWriter, r *http.Request) {
 			handler.GetTxsByAssetAndAddress(w, r, net, env)
 		}).Methods("GET")
-	router.HandleFunc("/txs/lock/{block_number}",
+	router.HandleFunc("/lock/txs/{block_number}",
 		func(w http.ResponseWriter, r *http.Request) {
 			handler.GetLockedTxsByBlockNumber(w, r, net, env)
 		}).Methods("GET")


### PR DESCRIPTION
## Problem

Another fix after PR #68 

## Solution

Use another url path.

## Testing Done and Results

## Follow-up Work Needed
