### PR TITLE
network: fix missing register lock tx proto

### DIFF
--- a/network/service.go
+++ b/network/service.go
@@ -64,6 +64,8 @@ func networkBuilder(env string) *network.Builder {
 	opcode.RegisterMessageType(opcode.Opcode(1124), &apiProtobuf.TxUpdateRequest{})
 	opcode.RegisterMessageType(opcode.Opcode(1125), &apiProtobuf.TxUpdateResponse{})
 	opcode.RegisterMessageType(opcode.Opcode(1126), &apiProtobuf.TxDeleteRequest{})
+	opcode.RegisterMessageType(opcode.Opcode(1127), &apiProtobuf.TxLockedRequest{})
+	opcode.RegisterMessageType(opcode.Opcode(1128), &apiProtobuf.TxLockedResponse{})
 
 	builder := network.NewBuilder(env)
 	builder.SetKeys(keys)


### PR DESCRIPTION
## Problem

Get lock txs failed with error `failed to get locked txs due to: types: message type not found, did you register it?`

## Solution

Register missing proto messages.

## Testing Done and Results

## Follow-up Work Needed
