### PR TITLE
Migration Error fix

### DIFF
--- a/store/migration/00005_tx_type.go
+++ b/store/migration/00005_tx_type.go
@@ -11,7 +11,7 @@ func init() {
 }
 
 func Up00005(tx *sql.Tx) error {
-	if _, err := tx.Exec(`ALTER TABLE transaction ADD COLUMN "type" TYPE VARCHAR(64)`); err != nil {
+	if _, err := tx.Exec(`ALTER TABLE transaction ADD COLUMN "type" VARCHAR(64)`); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
2019/07/15 14:55:03 goose up: ERROR 00005_tx_type.go: failed to run Go migration function func(*sql.Tx) error: pq: syntax error at or near "VARCHAR"

## Problem

Asana Link: 

## Solution

## Testing Done and Results

## Follow-up Work Needed
