### PR TITLE
server: add missing discovery plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 // indirect
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
+	github.com/ethereum/go-ethereum v1.8.22
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
 	github.com/herdius/herdius-core v0.0.0-20190723092552-54979e949581

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/aws/aws-sdk-go v1.19.35/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blockcypher/gobcy v1.3.1/go.mod h1:ZTXnnNN7aLqUWa8jTP65eEapWReeAIruKyorLxDRCBQ=
+github.com/btcsuite/btcd v0.0.0-20190427004231-96897255fd17 h1:m0N5Vg5nP3zEz8TREZpwX3gt4Biw3/8fbIf4A3hO96g=
 github.com/btcsuite/btcd v0.0.0-20190427004231-96897255fd17/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
@@ -49,6 +50,7 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/ethereum/go-ethereum v1.8.22 h1:y8RPBpBOF0/Gm8tV4Ut0WMa6RvY0e4XFIT6zASAOT0I=
 github.com/ethereum/go-ethereum v1.8.22/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
 github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
@@ -90,10 +92,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/herdius/herdius-core v0.0.0-20190722072507-5df8fd5afad8 h1:1uzvlInKQgVIQ/kCppCm3y4UZezMsRQeG5wkdnJavOI=
-github.com/herdius/herdius-core v0.0.0-20190722072507-5df8fd5afad8/go.mod h1:h6EqhQBP4bTYzS3LCGXcA66S8Yaz77Ry9+OnAAcgIcw=
-github.com/herdius/herdius-core v0.0.0-20190723064210-f00b87ba4e55 h1:Aw4A25dW2gN40OYSN1FV+E1vlO8bXubVEXvvCgdzpvU=
-github.com/herdius/herdius-core v0.0.0-20190723064210-f00b87ba4e55/go.mod h1:h6EqhQBP4bTYzS3LCGXcA66S8Yaz77Ry9+OnAAcgIcw=
 github.com/herdius/herdius-core v0.0.0-20190723092552-54979e949581 h1:fZqt+uR0TGayhoWhh+J7THMGVqkV021zPvhVHb57Exs=
 github.com/herdius/herdius-core v0.0.0-20190723092552-54979e949581/go.mod h1:h6EqhQBP4bTYzS3LCGXcA66S8Yaz77Ry9+OnAAcgIcw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
 	"github.com/herdius/herdius-blockchain-api/config"
 	"github.com/herdius/herdius-blockchain-api/handler"
 	"github.com/herdius/herdius-blockchain-api/middleware"
@@ -20,6 +21,7 @@ import (
 	"github.com/herdius/herdius-blockchain-api/store"
 	"github.com/herdius/herdius-blockchain-api/store/postgres"
 	coreNet "github.com/herdius/herdius-core/p2p/network"
+	"github.com/herdius/herdius-core/p2p/network/discovery"
 )
 
 func main() {
@@ -40,6 +42,10 @@ func LaunchServer() {
 
 	env := *envFlag
 	builder := network.GetNetworkBuilder(env)
+
+	// Register peer discovery plugin.
+	builder.AddPlugin(new(discovery.Plugin))
+
 	net, err := builder.Build()
 	if err != nil {
 		log.Fatalf("Failed to build network:%v", err)


### PR DESCRIPTION
Missing discovery plugin causes api failed to reconnect to supervisor
when supervisor node restart. This happens due to api continue using the
underlying dead connection, causing write broken pipe error.

Add the discovery plugin fixes the issue.

## Problem

Asana Link: https://app.asana.com/0/1125705697210963/1134857550854831

## Solution

Add missing discovery plugin.

## Testing Done and Results

`go run client.go -txtype=all` passed.

## Follow-up Work Needed
