### PR TITLE
Just a placeholder change to check the tx type in db

### DIFF
--- a/client.go
+++ b/client.go
@@ -143,14 +143,16 @@ func performAllTxs(endpoint string) {
 	}
 
 	log.Println("Register an ethereum address to created HER account: ", senderAddress)
+
+	msg = "Add New Tezos Address"
 	asset = &protobuf.Asset{
 		Category:              "crypto",
-		Symbol:                "ETH",
+		Symbol:                "XTZ",
 		Network:               "Herdius",
 		Value:                 0,
 		Fee:                   0,
 		Nonce:                 1,
-		ExternalSenderAddress: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		ExternalSenderAddress: "tz1WEKDqQrjP49KUBp27AKuzVC2fBv4veirm",
 	}
 
 	tx = protobuf.Tx{
@@ -405,12 +407,12 @@ func sendAccountRegisterTx(endpoint string) {
 
 	asset = &protobuf.Asset{
 		Category:              "crypto",
-		Symbol:                "ETH",
+		Symbol:                "XTZ",
 		Network:               "Herdius",
 		Value:                 0,
 		Fee:                   0,
 		Nonce:                 1,
-		ExternalSenderAddress: "0x9aA7E9819D781eFf5B239b572c4Fe8F964a899c9",
+		ExternalSenderAddress: "tz1WEKDqQrjP49KUBp27AKuzVC2fBv4veirm",
 	}
 
 	tx := protobuf.Tx{


### PR DESCRIPTION
## Problem
When reading transactions from blockchain server and blockchain api **tx-type** field is missing due to which we are not able to check the transaction type in other services. This works fine in locally. Just trying to make a new build and deploy to check if this could be solved.

[
  {
    "tx_id": "HTxc3f069a8abad725956a1fd04b018d9a0570d7a0b",
    "tx": {
      "sender_address": "HKbejAN57Z2qZAqbUcCurEmF8CxHU5UFe1",
      "sender_pubkey": "Arm8qBVmluU74W2d7Xp8NOQL5tejh1fP7H9LApRJvYuU",
      "asset": {
        "category": "crypto",
        "symbol": "HER",
        "network": "Herdius"
      },
      "message": "Register New HER Account",
      "sign": "9FrzQBToveo39K9kU4uydkj8wSWhVQRaAKDOiiO89/44EWzvNfQ1859ucZRHbOhAuiIeo2dSa+5v7L5bD/0bAA==",
      **"type": "update",**
      "status": "success"
    },
    "creationDt": {
      "seconds": 1567410092,
      "nanos": 1567410092279360000
    },
    "block_id": 1932
  }
]

Asana Link: 

## Solution

## Testing Done and Results

## Follow-up Work Needed
